### PR TITLE
After Episode 1: More Tests

### DIFF
--- a/test/budgie/tracking_test.exs
+++ b/test/budgie/tracking_test.exs
@@ -46,5 +46,32 @@ defmodule Budgie.TrackingTest do
       assert changeset.valid? == false
       assert %{end_date: ["must end after start date"]} = errors_on(changeset)
     end
+
+    test "list_budgets/0 returns all budgets" do
+      budget = budget_fixture()
+      assert Tracking.list_budgets() == [budget]
+    end
+
+    test "list_budgets/1 scopes to the provided user" do
+      user = Budgie.AccountsFixtures.user_fixture()
+
+      budget = budget_fixture(%{creator_id: user.id})
+      _other_budget = budget_fixture()
+
+      assert Tracking.list_budgets(user: user) == [
+               budget
+             ]
+    end
+
+    test "get_budget/1 returns the budget with given id" do
+      budget = budget_fixture()
+
+      assert Tracking.get_budget(budget.id) == budget
+    end
+
+    test "get_budget/1 returns nil when budget doesn't exist" do
+      _unrelated_budget = budget_fixture()
+      assert is_nil(Tracking.get_budget("10fe1ad8-6133-5d7d-b5c9-da29581bb923"))
+    end
   end
 end

--- a/test/budgie_web/live/budget_list_live_test.exs
+++ b/test/budgie_web/live/budget_list_live_test.exs
@@ -40,12 +40,12 @@ defmodule BudgieWeb.BudgetListLiveTest do
       conn = log_in_user(conn, user)
       {:ok, lv, _html} = live(conn, ~p"/budgets/new")
 
-      form = element(lv, "#create-budget-modal form")
-
-      html =
-        render_change(form, %{
+      form =
+        form(lv, "#create-budget-modal form", %{
           "budget" => %{"name" => ""}
         })
+
+      html = render_change(form)
 
       assert html =~ html_escape("can't be blank")
     end
@@ -57,10 +57,8 @@ defmodule BudgieWeb.BudgetListLiveTest do
       conn = log_in_user(conn, user)
       {:ok, lv, _html} = live(conn, ~p"/budgets/new")
 
-      form = form(lv, "#create-budget-modal form")
-
-      {:ok, _lv, html} =
-        render_submit(form, %{
+      form =
+        form(lv, "#create-budget-modal form", %{
           "budget" => %{
             "name" => "A new name",
             "description" => "The new description",
@@ -68,6 +66,9 @@ defmodule BudgieWeb.BudgetListLiveTest do
             "end_date" => "2025-01-31"
           }
         })
+
+      {:ok, _lv, html} =
+        render_submit(form)
         |> follow_redirect(conn)
 
       assert html =~ "Budget created"

--- a/test/budgie_web/live/budget_list_live_test.exs
+++ b/test/budgie_web/live/budget_list_live_test.exs
@@ -81,4 +81,47 @@ defmodule BudgieWeb.BudgetListLiveTest do
       assert created_budget.end_date == ~D[2025-01-31]
     end
   end
+
+  test "validation errors are presented when form is submitted with invalid input", %{
+    conn: conn,
+    user: user
+  } do
+    conn = log_in_user(conn, user)
+    {:ok, lv, _html} = live(conn, ~p"/budgets/new")
+
+    form =
+      form(lv, "#create-budget-modal form", %{
+        "budget" => %{"name" => ""}
+      })
+
+    html = render_submit(form)
+
+    assert html =~ html_escape("can't be blank")
+  end
+
+  test "end date before start date error is presented when form is submitted with invalid dates",
+       %{
+         conn: conn,
+         user: user
+       } do
+    conn = log_in_user(conn, user)
+    {:ok, lv, _html} = live(conn, ~p"/budgets/new")
+
+    # Creator ID isn't an input on the page, must be removed
+    attrs =
+      valid_budget_attributes(%{
+        start_date: ~D[2025-12-31],
+        end_date: ~D[2025-01-01]
+      })
+      |> Map.delete(:creator_id)
+
+    form =
+      form(lv, "#create-budget-modal form", %{
+        budget: attrs
+      })
+
+    html = render_submit(form)
+
+    assert html =~ "must end after start date"
+  end
 end


### PR DESCRIPTION
- Uses `form` instead of `element` to strengthen field submissions
- Adds tests for `list` and `get` methods in tracking context
- Adds assertions for invalid create form submissions