### PR TITLE
Episode 6: Budget Periods and Recursion

### DIFF
--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -30,4 +30,19 @@ defmodule Budgie.Tracking.Budget do
     )
     |> Budgie.Validations.validate_date_month_boundaries()
   end
+
+  def months_between(start_date, end_date, acc \\ []) do
+    end_of_month = Date.end_of_month(start_date)
+
+    # If we have reached the end of the timespan
+    if not Date.after?(end_date, end_of_month) do
+      Enum.reverse([%{start_date: start_date, end_date: end_of_month} | acc])
+    else
+      months_between(
+        Date.add(end_of_month, 1),
+        end_date,
+        [%{start_date: start_date, end_date: end_of_month} | acc]
+      )
+    end
+  end
 end

--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -12,6 +12,8 @@ defmodule Budgie.Tracking.Budget do
 
     belongs_to :creator, Budgie.Accounts.User
 
+    has_many :periods, Budgie.Tracking.BudgetPeriod
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -28,5 +28,6 @@ defmodule Budgie.Tracking.Budget do
       name: :budget_end_after_start,
       message: "must end after start date"
     )
+    |> Budgie.Validations.validate_date_month_boundaries()
   end
 end

--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -29,6 +29,18 @@ defmodule Budgie.Tracking.Budget do
       message: "must end after start date"
     )
     |> Budgie.Validations.validate_date_month_boundaries()
+    |> add_periods()
+  end
+
+  defp add_periods(%{valid?: false} = changeset), do: changeset
+
+  defp add_periods(changeset) do
+    start_date = Ecto.Changeset.get_field(changeset, :start_date)
+    end_date = Ecto.Changeset.get_field(changeset, :end_date)
+
+    changeset
+    |> Ecto.Changeset.change(%{periods: months_between(start_date, end_date)})
+    |> Ecto.Changeset.cast_assoc(:periods)
   end
 
   def months_between(start_date, end_date, acc \\ []) do

--- a/lib/budgie/tracking/budget_period.ex
+++ b/lib/budgie/tracking/budget_period.ex
@@ -1,0 +1,26 @@
+defmodule Budgie.Tracking.BudgetPeriod do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "budget_periods" do
+    field :start_date, :date
+    field :end_date, :date
+    belongs_to :budget, Budgie.Tracking.Budget
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(budget_period, attrs) do
+    budget_period
+    |> cast(attrs, [:start_date, :end_date, :budget_id])
+    |> validate_required([:start_date, :end_date, :budget_id])
+    |> check_constraint(:end_date,
+      name: :end_after_start,
+      message: "must end after start date"
+    )
+    |> unique_constraint([:budget_id, :start_date])
+  end
+end

--- a/lib/budgie/tracking/budget_period.ex
+++ b/lib/budgie/tracking/budget_period.ex
@@ -22,5 +22,6 @@ defmodule Budgie.Tracking.BudgetPeriod do
       message: "must end after start date"
     )
     |> unique_constraint([:budget_id, :start_date])
+    |> Budgie.Validations.validate_date_month_boundaries()
   end
 end

--- a/lib/budgie/validations.ex
+++ b/lib/budgie/validations.ex
@@ -1,0 +1,23 @@
+defmodule Budgie.Validations do
+  import Ecto.Changeset
+
+  def validate_date_month_boundaries(%Ecto.Changeset{valid?: false} = cs), do: cs
+
+  def validate_date_month_boundaries(%Ecto.Changeset{} = cs) do
+    start_date = get_field(cs, :start_date)
+    end_date = get_field(cs, :end_date)
+
+    cs =
+      if start_date != Date.beginning_of_month(start_date) do
+        add_error(cs, :start_date, "must be the beginning of a month")
+      else
+        cs
+      end
+
+    if end_date != Date.end_of_month(end_date) do
+      add_error(cs, :end_date, "must be the end of a month")
+    else
+      cs
+    end
+  end
+end

--- a/lib/budgie_web/live/budget_show_live.ex
+++ b/lib/budgie_web/live/budget_show_live.ex
@@ -8,7 +8,7 @@ defmodule BudgieWeb.BudgetShowLive do
     budget =
       Tracking.get_budget(id,
         user: socket.assigns.current_user,
-        preload: :creator
+        preload: [:creator, :periods]
       )
 
     if budget do

--- a/lib/budgie_web/live/budget_show_live.html.heex
+++ b/lib/budgie_web/live/budget_show_live.html.heex
@@ -58,6 +58,18 @@
   </div>
 </div>
 
+<div class="grid grid-cols-1 gap-4 mt-6">
+  <div
+    :for={period <- @budget.periods}
+    class="bg-white rounded shadow-sm p-4 cursor-pointer hover:shadow-md transition-shadow"
+  >
+    <div class="flex justify-between items-center mb-3">
+      <h3 class="font-medium text-gray-900">
+        {period.start_date}
+      </h3>
+    </div>
+  </div>
+</div>
 <.table id="transactions" rows={@transactions}>
   <:col :let={transaction} label="Description">{transaction.description}</:col>
   <:col :let={transaction} label="Date">{transaction.effective_date}</:col>

--- a/lib/budgie_web/live/create_budget_dialog.ex
+++ b/lib/budgie_web/live/create_budget_dialog.ex
@@ -28,11 +28,11 @@ defmodule BudgieWeb.CreateBudgetDialog do
   def handle_event("save", %{"budget" => params}, socket) do
     params = Map.put(params, "creator_id", socket.assigns.current_user.id)
 
-    with {:ok, %Budget{}} <- Tracking.create_budget(params) do
+    with {:ok, %Budget{} = budget} <- Tracking.create_budget(params) do
       socket =
         socket
         |> put_flash(:info, "Budget created")
-        |> push_navigate(to: ~p"/budgets", replace: true)
+        |> push_navigate(to: ~p"/budgets/#{budget}", replace: true)
 
       {:noreply, socket}
     else

--- a/priv/repo/migrations/20250406182137_create_budget_periods.exs
+++ b/priv/repo/migrations/20250406182137_create_budget_periods.exs
@@ -1,0 +1,21 @@
+defmodule Budgie.Repo.Migrations.CreateBudgetPeriods do
+  use Ecto.Migration
+
+  def change do
+    create table(:budget_periods, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :start_date, :date
+      add :end_date, :date
+      add :budget_id, references(:budgets, on_delete: :delete_all, type: :binary_id)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:budget_periods, [:budget_id, :start_date])
+
+    create constraint(:budget_periods, :end_after_start,
+             check: "end_date > start_date",
+             comment: "Period must end after its start date"
+           )
+  end
+end

--- a/test/budgie/tracking/budget_period_test.exs
+++ b/test/budgie/tracking/budget_period_test.exs
@@ -1,0 +1,49 @@
+defmodule Budgie.Tracking.BudgetPeriodTest do
+  use Budgie.DataCase
+
+  alias Budgie.Tracking.BudgetPeriod
+
+  describe "changeset/2" do
+    test "fails when start date is after the beginning of the month" do
+      attrs = params_with_assocs(:budget_period, start_date: ~D[2025-01-05])
+
+      changeset = BudgetPeriod.changeset(%BudgetPeriod{}, attrs)
+
+      refute changeset.valid?
+
+      assert %{start_date: ["must be the beginning of a month"]} = errors_on(changeset)
+    end
+
+    test "fails when end date is before the end of the month" do
+      attrs = params_with_assocs(:budget_period, end_date: ~D[2025-01-15])
+
+      changeset = BudgetPeriod.changeset(%BudgetPeriod{}, attrs)
+
+      refute changeset.valid?
+
+      assert %{end_date: ["must be the end of a month"]} = errors_on(changeset)
+    end
+
+    test "fails when both start and end date are incorrect" do
+      attrs =
+        params_with_assocs(:budget_period, start_date: ~D[2025-01-05], end_date: ~D[2025-01-15])
+
+      changeset = BudgetPeriod.changeset(%BudgetPeriod{}, attrs)
+
+      refute changeset.valid?
+
+      assert %{
+               start_date: ["must be the beginning of a month"],
+               end_date: ["must be the end of a month"]
+             } = errors_on(changeset)
+    end
+
+    test "valid when start and end dates are correct" do
+      attrs = params_with_assocs(:budget_period)
+
+      changeset = BudgetPeriod.changeset(%BudgetPeriod{}, attrs)
+
+      assert changeset.valid?
+    end
+  end
+end

--- a/test/budgie/tracking/budget_test.exs
+++ b/test/budgie/tracking/budget_test.exs
@@ -1,0 +1,29 @@
+defmodule Budgie.Tracking.BudgetTest do
+  use Budgie.DataCase
+
+  alias Budgie.Tracking.Budget
+
+  describe "months_between/3" do
+    test "provides a single month when given a single month range" do
+      start_date = ~D[2025-01-01]
+      end_date = ~D[2025-01-31]
+
+      result = Budget.months_between(start_date, end_date)
+
+      assert result == [%{start_date: start_date, end_date: end_date}]
+    end
+
+    test "provides three months when given a quarter range" do
+      start_date = ~D[2025-01-01]
+      end_date = ~D[2025-03-31]
+
+      result = Budget.months_between(start_date, end_date)
+
+      assert result == [
+               %{start_date: ~D[2025-01-01], end_date: ~D[2025-01-31]},
+               %{start_date: ~D[2025-02-01], end_date: ~D[2025-02-28]},
+               %{start_date: ~D[2025-03-01], end_date: ~D[2025-03-31]}
+             ]
+    end
+  end
+end

--- a/test/budgie/tracking_test.exs
+++ b/test/budgie/tracking_test.exs
@@ -31,8 +31,8 @@ defmodule Budgie.TrackingTest do
     test "create_budget/1 requires valid dates" do
       attrs =
         params_with_assocs(:budget,
-          start_date: ~D[2025-12-31],
-          end_date: ~D[2025-01-01]
+          start_date: ~D[2025-12-01],
+          end_date: ~D[2025-01-31]
         )
 
       assert {:error, %Ecto.Changeset{} = changeset} =

--- a/test/budgie_web/live/budget_list_live_test.exs
+++ b/test/budgie_web/live/budget_list_live_test.exs
@@ -106,8 +106,8 @@ defmodule BudgieWeb.BudgetListLiveTest do
 
     attrs =
       params_for(:budget,
-        start_date: ~D[2025-12-31],
-        end_date: ~D[2025-01-01]
+        start_date: ~D[2025-12-01],
+        end_date: ~D[2025-01-31]
       )
 
     form =

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -26,6 +26,14 @@ defmodule Budgie.Factory do
     }
   end
 
+  def budget_period_factory do
+    %Tracking.BudgetPeriod{
+      budget: build(:budget),
+      start_date: ~D[2025-01-01],
+      end_date: ~D[2025-01-31]
+    }
+  end
+
   def budget_transaction_factory do
     %Tracking.BudgetTransaction{
       effective_date: ~D[2025-01-01],


### PR DESCRIPTION
- Adds new `BudgetPeriod` model
- Adds validations for `Budget` and `BudgetPeriod`, ensuring they align with month boundaries
- Creates one monthly `BudgetPeriod` for each month of a `Budget`'s time range
- Adds basic `BudgetPeriod` list to the budget show page