### PR TITLE
Episode 9: Advanced Forms with Embedded Schemas and Multi

### DIFF
--- a/lib/budgie/tracking.ex
+++ b/lib/budgie/tracking.ex
@@ -7,12 +7,6 @@ defmodule Budgie.Tracking do
   alias Budgie.Tracking.BudgetJoinLink
   alias Budgie.Tracking.BudgetPeriod
 
-  def create_budget(attrs \\ %{}) do
-    %Budget{}
-    |> Budget.changeset(attrs)
-    |> Repo.insert()
-  end
-
   def list_budgets, do: list_budgets([])
 
   def list_budgets(criteria) when is_list(criteria) do
@@ -50,10 +44,6 @@ defmodule Budgie.Tracking do
       _, query ->
         query
     end)
-  end
-
-  def change_budget(budget, attrs \\ %{}) do
-    Budget.changeset(budget, attrs)
   end
 
   alias Budgie.Tracking.BudgetTransaction

--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -26,10 +26,7 @@ defmodule Budgie.Tracking.Budget do
     |> validate_required([:name, :start_date, :end_date, :creator_id])
     |> validate_length(:name, max: 100)
     |> validate_length(:description, max: 500)
-    |> check_constraint(:end_date,
-      name: :budget_end_after_start,
-      message: "must end after start date"
-    )
+    |> validate_end_date_after_start_date()
     |> Budgie.Validations.validate_date_month_boundaries()
     |> add_periods()
   end
@@ -43,6 +40,18 @@ defmodule Budgie.Tracking.Budget do
     changeset
     |> Ecto.Changeset.change(%{periods: months_between(start_date, end_date)})
     |> Ecto.Changeset.cast_assoc(:periods)
+  end
+
+  defp validate_end_date_after_start_date(changeset) do
+    start_date = get_field(changeset, :start_date)
+    end_date = get_field(changeset, :end_date)
+
+    if not is_nil(start_date) and not is_nil(end_date) and
+         Date.compare(start_date, end_date) != :lt do
+      add_error(changeset, :end_date, "must end after start date")
+    else
+      changeset
+    end
   end
 
   def months_between(start_date, end_date, acc \\ []) do

--- a/lib/budgie/tracking/forms/create_budget.ex
+++ b/lib/budgie/tracking/forms/create_budget.ex
@@ -1,0 +1,74 @@
+defmodule Budgie.Tracking.Forms.CreateBudget do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias __MODULE__
+  alias Budgie.Tracking.Budget
+  alias Budgie.Tracking.BudgetTransaction
+  alias Budgie.Repo
+
+  @maximum_period_funding_amount 100_000
+
+  embedded_schema do
+    field :period_funding_amount, :decimal
+    embeds_one(:budget, Budget)
+  end
+
+  def new(schema \\ %CreateBudget{}) do
+    changeset(schema, %{})
+  end
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:period_funding_amount])
+    |> validate_number(:period_funding_amount,
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: @maximum_period_funding_amount
+    )
+    |> cast_embed(:budget, with: &Budget.changeset/2)
+  end
+
+  def submit(form, attrs) do
+    result =
+      form.source.data
+      |> changeset(attrs)
+      |> Ecto.Changeset.apply_action(:insert)
+
+    with {:ok, data} <- result do
+      data
+      |> construct_multi()
+      |> Repo.transaction()
+    end
+  end
+
+  defp construct_multi(data) do
+    Ecto.Multi.new()
+    |> Ecto.Multi.insert(:budget, data.budget)
+    |> Ecto.Multi.run(:fund_budget, fn repo, %{budget: budget} ->
+      fund_budget_if_necessary(repo, budget, data)
+    end)
+  end
+
+  defp fund_budget_if_necessary(_repo, _budget, %{period_funding_amount: nil}), do: {:ok, []}
+
+  defp fund_budget_if_necessary(repo, budget, %{period_funding_amount: amount}) do
+    transactions =
+      Enum.map(budget.periods, fn period ->
+        BudgetTransaction.changeset(
+          %BudgetTransaction{},
+          %{
+            budget_id: budget.id,
+            type: :funding,
+            amount: amount,
+            effective_date: period.start_date,
+            description: "Recurring funding"
+          },
+          budget
+        )
+        |> repo.insert!()
+      end)
+
+    {:ok, transactions}
+  end
+end

--- a/lib/budgie_web/live/create_budget_dialog.ex
+++ b/lib/budgie_web/live/create_budget_dialog.ex
@@ -1,34 +1,36 @@
 defmodule BudgieWeb.CreateBudgetDialog do
   use BudgieWeb, :live_component
 
-  alias Budgie.Tracking
   alias Budgie.Tracking.Budget
+  alias Budgie.Tracking.Forms.CreateBudget
 
   @impl true
   def update(assigns, socket) do
-    changeset = Tracking.change_budget(%Budget{})
+    changeset = CreateBudget.new()
 
     socket =
       socket
       |> assign(assigns)
-      |> assign(form: to_form(changeset))
+      |> assign_form(changeset)
 
     {:ok, socket}
   end
 
   @impl true
-  def handle_event("validate", %{"budget" => params}, socket) do
+  def handle_event("validate", %{"create_budget" => params}, socket) do
     changeset =
-      Tracking.change_budget(%Budget{}, params)
+      CreateBudget.new()
+      |> CreateBudget.changeset(params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign(socket, form: to_form(changeset))}
+    {:noreply, assign_form(socket, changeset)}
   end
 
-  def handle_event("save", %{"budget" => params}, socket) do
-    params = Map.put(params, "creator_id", socket.assigns.current_user.id)
+  def handle_event("save", %{"create_budget" => params}, socket) do
+    params = put_in(params, ["budget", "creator_id"], socket.assigns.current_user.id)
 
-    with {:ok, %Budget{} = budget} <- Tracking.create_budget(params) do
+    with {:ok, %{budget: %Budget{} = budget}} <-
+           CreateBudget.submit(socket.assigns.form, params) do
       socket =
         socket
         |> put_flash(:info, "Budget created")
@@ -36,7 +38,11 @@ defmodule BudgieWeb.CreateBudgetDialog do
 
       {:noreply, socket}
     else
-      {:error, changeset} -> {:noreply, assign(socket, form: to_form(changeset))}
+      {:error, changeset} -> {:noreply, assign_form(socket, changeset)}
     end
+  end
+
+  defp assign_form(socket, changeset) do
+    assign(socket, :form, to_form(changeset))
   end
 end

--- a/lib/budgie_web/live/create_budget_dialog.html.heex
+++ b/lib/budgie_web/live/create_budget_dialog.html.heex
@@ -10,29 +10,42 @@
     phx-change="validate"
     phx-submit="save"
   >
-    <div class="space-y-4">
-      <.input
-        field={@form[:name]}
-        label="Budget Name"
-        placeholder="e.g., Groceries, Entertainment"
-        autofocus
-        required
-      />
-      <.input
-        field={@form[:description]}
-        label="Description"
-        type="textarea"
-        placeholder="What is this budget for?"
-      />
-    </div>
-
-    <div class="space-y-4">
-      <h2 class="text-lg font-semibold">Budget Period</h2>
-
-      <div class="grid grid-cols-2 gap-4">
-        <.input field={@form[:start_date]} label="Start Date" type="date" />
-        <.input field={@form[:end_date]} label="End Date" type="date" />
+    <.inputs_for :let={budget} field={@form[:budget]}>
+      <div class="space-y-4">
+        <.input
+          field={budget[:name]}
+          label="Budget Name"
+          placeholder="e.g., Groceries, Entertainment"
+          autofocus
+          required
+        />
+        <.input
+          field={budget[:description]}
+          label="Description"
+          type="textarea"
+          placeholder="What is this budget for?"
+        />
       </div>
+
+      <div class="space-y-4">
+        <h2 class="text-lg font-semibold">Budget Period</h2>
+
+        <div class="grid grid-cols-2 gap-4">
+          <.input field={budget[:start_date]} label="Start Date" type="date" />
+          <.input field={budget[:end_date]} label="End Date" type="date" />
+        </div>
+      </div>
+    </.inputs_for>
+
+    <div class="space-y-4">
+      <h2 class="text-lg font-semibold">Funding</h2>
+      <.input
+        field={@form[:period_funding_amount]}
+        label="Monthly Amount (optional)"
+        type="number"
+        step="0.01"
+        placeholder="$0.00"
+      />
     </div>
 
     <div class="pt-4">

--- a/test/budgie/tracking/forms/create_budget_test.exs
+++ b/test/budgie/tracking/forms/create_budget_test.exs
@@ -1,0 +1,190 @@
+defmodule Budgie.Tracking.Forms.CreateBudgetTest do
+  use Budgie.DataCase, async: true
+
+  alias Budgie.Tracking.Forms.CreateBudget
+
+  describe "changeset/2" do
+    test "validates monthly funding amount" do
+      changeset =
+        CreateBudget.changeset(%CreateBudget{}, %{
+          period_funding_amount: -1,
+          budget: params_with_assocs(:budget)
+        })
+
+      assert changeset.valid? == false
+
+      errors = errors_on(changeset)
+
+      assert %{period_funding_amount: ["must be greater than or equal to 0"]} = errors
+    end
+
+    test "validates budget name presence" do
+      budget_attrs =
+        params_with_assocs(:budget)
+        |> Map.delete(:name)
+
+      changeset =
+        CreateBudget.changeset(%CreateBudget{}, %{
+          period_funding_amount: 1000,
+          budget: budget_attrs
+        })
+
+      assert changeset.valid? == false
+      errors = errors_on(changeset)
+
+      assert %{budget: %{name: ["can't be blank"]}} = errors
+    end
+
+    test "returns valid with correct attributes" do
+      attrs = %{
+        period_funding_amount: 5000,
+        budget: params_with_assocs(:budget)
+      }
+
+      changeset = CreateBudget.changeset(%CreateBudget{}, attrs)
+
+      assert changeset.valid? == true
+    end
+
+    test "validates budget date requirements" do
+      budget_attrs =
+        params_with_assocs(:budget)
+        |> Map.merge(%{
+          start_date: ~D[2025-12-01],
+          end_date: ~D[2025-01-31]
+        })
+
+      changeset =
+        CreateBudget.changeset(%CreateBudget{}, %{
+          period_funding_amount: 1000,
+          budget: budget_attrs
+        })
+
+      assert changeset.valid? == false
+      errors = errors_on(changeset)
+
+      assert %{budget: %{end_date: ["must end after start date"]}} = errors
+    end
+  end
+
+  describe "submit/2" do
+    test "creates funded budget when funding amount is provided" do
+      user = insert(:user)
+
+      form = Phoenix.Component.to_form(CreateBudget.new())
+
+      attrs = %{
+        "period_funding_amount" => 123,
+        "budget" => string_params_for(:budget, creator_id: user.id)
+      }
+
+      result = CreateBudget.submit(form, attrs)
+
+      assert {:ok, %{budget: budget, fund_budget: transactions}} = result
+      assert budget.creator_id == user.id
+      assert Enum.count(budget.periods) == Enum.count(transactions)
+
+      assert Enum.all?(transactions, fn tx ->
+               tx.type == :funding and
+                 tx.amount == Decimal.new("123") and
+                 tx.description == "Recurring funding"
+             end)
+    end
+
+    test "returns invalid changeset when period funding amount is invalid" do
+      user = insert(:user)
+
+      form = Phoenix.Component.to_form(CreateBudget.new())
+
+      attrs = %{
+        "period_funding_amount" => -100,
+        "budget" => string_params_for(:budget, creator_id: user.id)
+      }
+
+      result = CreateBudget.submit(form, attrs)
+
+      assert {:error, changeset} = result
+      assert changeset.valid? == false
+
+      assert %{period_funding_amount: ["must be greater than or equal to 0"]} =
+               errors_on(changeset)
+    end
+
+    test "returns empty transaction list when funding amount is nil" do
+      user = insert(:user)
+
+      form = Phoenix.Component.to_form(CreateBudget.new())
+
+      attrs = %{
+        "period_funding_amount" => nil,
+        "budget" => string_params_for(:budget, creator_id: user.id)
+      }
+
+      result = CreateBudget.submit(form, attrs)
+
+      assert {:ok, %{budget: budget, fund_budget: transactions}} = result
+      assert budget.creator_id == user.id
+      assert [] = transactions
+    end
+
+    test "creates periods along with the budget" do
+      user = insert(:user)
+
+      form = Phoenix.Component.to_form(CreateBudget.new())
+
+      budget_attrs =
+        string_params_for(:budget)
+        |> Map.merge(%{
+          "start_date" => "2025-01-01",
+          "end_date" => "2025-02-28",
+          "creator_id" => user.id
+        })
+
+      attrs = %{
+        "period_funding_amount" => nil,
+        "budget" => budget_attrs
+      }
+
+      result = CreateBudget.submit(form, attrs)
+
+      assert {:ok, %{budget: budget, fund_budget: _transactions}} = result
+      assert Enum.count(budget.periods) == 2
+
+      [january_period, february_period] = budget.periods
+      assert january_period.start_date == ~D[2025-01-01]
+      assert january_period.end_date == ~D[2025-01-31]
+      assert february_period.start_date == ~D[2025-02-01]
+      assert february_period.end_date == ~D[2025-02-28]
+    end
+
+    test "creates budget with all correct attributes" do
+      user = insert(:user)
+
+      form = Phoenix.Component.to_form(CreateBudget.new())
+
+      budget_attrs =
+        string_params_for(:budget)
+        |> Map.merge(%{
+          "name" => "Test Budget",
+          "description" => "Test Description",
+          "start_date" => "2025-03-01",
+          "end_date" => "2025-03-31",
+          "creator_id" => user.id
+        })
+
+      attrs = %{
+        "period_funding_amount" => nil,
+        "budget" => budget_attrs
+      }
+
+      result = CreateBudget.submit(form, attrs)
+
+      assert {:ok, %{budget: budget, fund_budget: _transactions}} = result
+      assert budget.name == "Test Budget"
+      assert budget.description == "Test Description"
+      assert budget.start_date == ~D[2025-03-01]
+      assert budget.end_date == ~D[2025-03-31]
+      assert budget.creator_id == user.id
+    end
+  end
+end

--- a/test/budgie/tracking_test.exs
+++ b/test/budgie/tracking_test.exs
@@ -4,65 +4,6 @@ defmodule Budgie.TrackingTest do
   alias Budgie.Tracking
 
   describe "budgets" do
-    alias Budgie.Tracking.Budget
-
-    test "create_budget/1 with valid data creates budget" do
-      attrs = params_with_assocs(:budget)
-
-      assert {:ok, %Budget{} = budget} = Tracking.create_budget(attrs)
-      assert budget.name == attrs.name
-      assert budget.description == attrs.description
-      assert budget.start_date == attrs.start_date
-      assert budget.end_date == attrs.end_date
-      assert budget.creator_id == attrs.creator_id
-    end
-
-    test "create_budget/1 with valid data creates periods along with the budget" do
-      user = insert(:user)
-
-      valid_attrs = %{
-        name: "some name",
-        description: "some description",
-        start_date: ~D[2025-01-01],
-        end_date: ~D[2025-02-28],
-        creator_id: user.id
-      }
-
-      assert {:ok, %Budget{} = budget} = Tracking.create_budget(valid_attrs)
-      assert Enum.count(budget.periods) == 2
-
-      [january_period, february_period] = budget.periods
-      assert january_period.start_date == ~D[2025-01-01]
-      assert january_period.end_date == ~D[2025-01-31]
-      assert february_period.start_date == ~D[2025-02-01]
-      assert february_period.end_date == ~D[2025-02-28]
-    end
-
-    test "create_budget/1 requires name" do
-      attrs =
-        params_with_assocs(:budget)
-        |> Map.delete(:name)
-
-      assert {:error, %Ecto.Changeset{} = changeset} = Tracking.create_budget(attrs)
-
-      assert changeset.valid? == false
-      assert %{name: ["can't be blank"]} = errors_on(changeset)
-    end
-
-    test "create_budget/1 requires valid dates" do
-      attrs =
-        params_with_assocs(:budget,
-          start_date: ~D[2025-12-01],
-          end_date: ~D[2025-01-31]
-        )
-
-      assert {:error, %Ecto.Changeset{} = changeset} =
-               Tracking.create_budget(attrs)
-
-      assert changeset.valid? == false
-      assert %{end_date: ["must end after start date"]} = errors_on(changeset)
-    end
-
     test "list_budgets/0 returns all budgets" do
       budgets = insert_pair(:budget)
 


### PR DESCRIPTION
- Adds `CreateBudget` form schema, using embedded schemas
- Uses an Ecto Multi to fund each period of a newly-created budget
- Adds tests to cover the new additions
- Removes unused methods from the `Tracking` context